### PR TITLE
Removed deprecated crypto dependency

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -2,7 +2,7 @@ import jwt from 'jsonwebtoken';
 import passport from 'passport';
 import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt';
 import { Strategy as LocalStrategy } from 'passport-local';
-import crypto from 'crypto';
+import crypto from Crypto;
 
 const createAuthModule = () => {
   const secret = process.env.JWT_SECRET || 'default_secret';

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "compression": "^1.7.4",
         "connect-mongodb-session": "^5.0.0",
         "cookie-parser": "^1.4.5",
-        "crypto": "^1.0.1",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
         "express-session": "^1.17.1",
@@ -798,12 +797,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
-    },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "compression": "^1.7.4",
     "connect-mongodb-session": "^5.0.0",
     "cookie-parser": "^1.4.5",
-    "crypto": "^1.0.1",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "express-session": "^1.17.1",


### PR DESCRIPTION
Crypto module is now part of NodeJs.
Also the following dependencies doesn't seems used and trigger performance/security warnings :

inflight@1.0.6
glob@7.1.6
glob@7.1.2 -> twice ?!
formidable@1.2.6
superagent@3.8.3
mkdirp@0.5.1

Maybe consider removing them.